### PR TITLE
Use markdown api messages

### DIFF
--- a/src/ChatModel/ChatModel.ts
+++ b/src/ChatModel/ChatModel.ts
@@ -18,6 +18,9 @@ export interface ChatMessage {
   finishReason?: ChatMessageFinishReason;
 }
 
+/**
+ * A section of a message. A complete message in a Conversation is made up of one or more blocks.
+ */
 export interface MessageBlock {
   type: "text" | "code";
   /**
@@ -28,10 +31,16 @@ export interface MessageBlock {
   content: string;
 }
 
+/**
+ * A text block in a message. The content is markdown text.
+ */
 export interface TextBlock extends MessageBlock {
   type: "text";
 }
 
+/**
+ * A code block in a message. The content is the code itself without the code fences or language identifier.
+ */
 export interface CodeBlock extends MessageBlock {
   type: "code";
   /**

--- a/src/ChatModel/Implementations/PaLMChatModel.ts
+++ b/src/ChatModel/Implementations/PaLMChatModel.ts
@@ -41,9 +41,9 @@ interface PaLMExample {
 }
 
 enum PaLMContentBlockedReason {
-  BLOCKED_REASON_UNSPECIFIED = "Blocked reason unspecified",
-  SAFETY = "Safety",
-  OTHER = "Other",
+  BLOCKED_REASON_UNSPECIFIED = "BLOCKED_REASON_UNSPECIFIED",
+  SAFETY = "SAFETY",
+  OTHER = "OTHER",
 }
 
 export class PaLMChatModel implements ChatModel {
@@ -64,8 +64,10 @@ export class PaLMChatModel implements ChatModel {
         prompt: this.convertToPaLMPrompt(request.conversation),
       })
       .then((response) => {
-        const candidates = response[0] as PalMMessage[];
-        const filters = response[1] as PaLMContentFilter[];
+        const candidates: PalMMessage[] | null = response[0]
+          .candidates as PalMMessage[];
+        const filters: PaLMContentFilter[] | null = response[0]
+          .filters as PaLMContentFilter[];
         if (candidates && candidates.length > 0) {
           return {
             success: true,
@@ -75,7 +77,7 @@ export class PaLMChatModel implements ChatModel {
             },
           };
         } else {
-          if (filters.length > 0) {
+          if (filters && filters.length > 0) {
             return {
               success: false,
               errorMessage: this.getFilterErrorMessage(filters),
@@ -141,11 +143,12 @@ export class PaLMChatModel implements ChatModel {
   convertToPaLMMessages(chatMessages: ChatMessage[]): PalMMessage[] {
     // Add messages to the beginning of the conversation history to provide examples/set the stage
     const introMessages: ChatMessage[] = getExampleMessages();
-    chatMessages.splice(0, 0, ...introMessages);
+
+    const messages: ChatMessage[] = [...introMessages, ...chatMessages];
 
     // Convert system messages to user messages so that PaLM can handle it (only supports two authors)
     const messagesWithAcceptedAuthorship: ChatMessage[] = [];
-    for (const message of chatMessages) {
+    for (const message of messages) {
       if (message.role === ChatRole.System) {
         messagesWithAcceptedAuthorship.push({
           ...message,

--- a/src/Conversation/messageBlockHelpers.ts
+++ b/src/Conversation/messageBlockHelpers.ts
@@ -1,9 +1,70 @@
-import { MessageBlock } from "../ChatModel/ChatModel";
+import { CodeBlock, MessageBlock, TextBlock } from "../ChatModel/ChatModel";
 
-export function stringToMessageBlocks(text: string): MessageBlock[] {
-  return JSON.parse(text) as MessageBlock[]; // TODO: Change to parsing the markdown response as discussed in class
+/**
+ * Converts a string input into an array of message blocks. Input is assumed to be Markdown.
+ * A message block can be either a text block or a code block.
+ * A text block is a block of text that does not contain any code fences.
+ * A code block is a block of code that is enclosed by a pair of code fences.
+ * @param markdown The Markdown string to convert into message blocks.
+ * @returns An array of message blocks.
+ * @throws An error if the number of code fences is odd.
+ */
+export function stringToMessageBlocks(markdown: string): MessageBlock[] {
+  const sections = markdown.split("```");
+
+  if (sections.length % 2 === 0) {
+    throw new Error("Odd number of code fences");
+  }
+
+  const blocks: MessageBlock[] = [];
+  for (let i = 0; i < sections.length; i++) {
+    let content = sections[i];
+    if (content) {
+      if (i % 2 === 0) {
+        // text block
+        content = content.trim();
+        blocks.push({ type: "text", content: content } as TextBlock);
+      } else {
+        // code block
+        const lines = content.split("\n");
+        let languageId = lines.shift();
+        if (languageId === "") {
+          languageId = undefined;
+        }
+        let codeContent = lines.join("\n");
+        if (codeContent.endsWith("\n")) {
+          // don't want to trim() completely because we want to preserve indentation
+          codeContent = codeContent.slice(0, -1);
+        }
+        blocks.push({
+          type: "code",
+          content: codeContent,
+          languageId: languageId,
+        } as CodeBlock);
+      }
+    }
+  }
+
+  return blocks;
 }
 
+/**
+ * Converts a list of message blocks to a Markdown string.
+ * Code blocks will be converted to Markdown code fences with language identifiers if available.
+ *
+ * @param messageBlocks The list of message blocks to convert to a Markdown string.
+ */
 export function messageBlocksToString(messageBlocks: MessageBlock[]): string {
-  return JSON.stringify(messageBlocks); // TODO: Change to sending markdown formatted request as discussed in class
+  let markdown = "";
+  for (const block of messageBlocks) {
+    if (block.type === "text") {
+      markdown += `${block.content}\n`;
+    } else if (block.type === "code") {
+      markdown += `\`\`\`${(block as CodeBlock).languageId}\n${
+        block.content
+      }\n\`\`\`\n`;
+    }
+  }
+  markdown = markdown.slice(0, -1); // remove last newline
+  return markdown;
 }

--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -39,33 +39,10 @@ export const LLM_PROVIDER_NOT_SET_ERROR_MESSAGE =
   "Provider not set. Please choose a provider for the byoLAD extension.";
 
 // Conversation/message constants
-export const CONTEXT_INSTRUCTION = `You are a friendly coding assistant, helping answer a developer's questions about their code as they are writing/editing it.
-You are a tool integrated into the user's IDE, so you need to make clear how to apply your suggestions in the context of their code files.
+export const CONTEXT_INSTRUCTION = `You are a friendly coding assistant helping to answer a developer's questions about their code as they are writing/editing it.
 The user will provide you with requests/questions and optionally code samples to modify or use as reference.
 Keep your answers as consise as possible while still being helpful to the user.
-You can only respond in valid JSON. You must use the following JSON format to respond to the user's request/questions and code samples (alternating between "text" type and "code" type blocks using as few or as many as needed of either):
-[
-  {
-    "type": "text",
-    "content": "<any commentary or explanations between code samples>"
-  },
-  {
-    "type": "code",
-    "content": "<code sample without code fences or language identifier>",
-    "languageId": "<markdown language identifier>",
-    "linesInUserSourceFile": {
-      "start": <0-indexed start line of code in the source file (inclusive)>,
-      "end": <0-indexed end line of code in the source file (exclusive)>
-    }
-  },
-  {
-    "type": "text",
-    "content": "<additional commentary if needed>"
-  }
-]
-If your response is modifying the user's code, you must provide the "linesInUserSourceFile" field in the "code" type block as defined above if the user provided "linesInUserSourceFile" in that associated "code" type block.
-- This "linesInUserSourceFile" field is the range of code in the user's source file (that they are editing) that your code corresponds to. When you suggest modifications/edits to the code, the user needs to know exactly which lines in their document they should replace with your provided code.
-- For example, if the user gives you code with '"linesInUserSourceFile": {"start": 0, "end": 10}' of a document they are working in and you suggest modifications to that code that is more concise, using only 5 lines instead of 10, you would still return '"linesInUserSourceFile": {"start": 0, "end": 10}' alongside your more concise suggestion. This is because those are the lines in the user's source file that your suggested code is meant to replace.
-The only time you would provide a "linesInUserSourceFile" field that is different than the values of the user-provided code you are modifying is if you are only modifying a small portion of the user's code and don't want to return an excessive amount of equivalent code.
-- For example, if the user gives you code with '"linesInUserSourceFile": {"start": 50, "end": 100}' and you return a smaller snippet of code is only meant to replace lines 60-75 of the user's source code file (which is within the user-provided sample), you would return a code suggestion with '"linesInUserSourceFile": {"start": 60, "end": 75}'.
-- This is useful for when the user gives you a large amount of code and you only want to modify a small portion of it. This way, you don't have to return a large amount of text that includes the user's original, unmodified code. Instead, you can be more specific and concise, but the user still needs to know exactly where in their source file the changes should be applied.`;
+You MUST respond in valid Markdown format with any code samples using code fences and a language identifier.
+This is necessary so the user can easily see which parts of your response are code and which parts are just descriptive/explanatory Markdown text.
+If the user's request is not related to code or programming, you should respond with something like "I'm sorry, I can't help with that. Do you have a question about your code?"
+If the user provides you with a large code sample and you only need to modify a small portion of it, you should only return the modified portion of the code only and indicate which part you are modifying/improving/replacing.`;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,7 +3,8 @@ import * as assert from "assert";
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from "vscode";
-// import * as myExtension from '../../extension';
+import { CodeBlock, MessageBlock, TextBlock } from "../../ChatModel/ChatModel";
+import { stringToMessageBlocks } from "../../Conversation/messageBlockHelpers";
 
 suite("Extension Test Suite", () => {
   vscode.window.showInformationMessage("Start all tests.");
@@ -11,5 +12,85 @@ suite("Extension Test Suite", () => {
   test("Sample test", () => {
     assert.strictEqual(-1, [1, 2, 3].indexOf(5));
     assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+  });
+
+  test("stringToMessageBlocks should return an array of message blocks", () => {
+    const input = "Hello, world!";
+    const expectedOutput: MessageBlock[] = [
+      { type: "text", content: "Hello, world!" } as TextBlock,
+    ];
+    const actualOutput = stringToMessageBlocks(input);
+    assert.deepStrictEqual(actualOutput, expectedOutput);
+  });
+
+  test("stringToMessageBlocks should handle empty input", () => {
+    const input = "";
+    const expectedOutput: MessageBlock[] = [];
+    const actualOutput = stringToMessageBlocks(input);
+    assert.deepStrictEqual(actualOutput, expectedOutput);
+  });
+
+  test("stringToMesaageBlocks should handle a single code block", () => {
+    const input = "```python\n    print('Hello, world!')\n```";
+    const expectedOutput: MessageBlock[] = [
+      {
+        type: "code",
+        content: "    print('Hello, world!')",
+        languageId: "python",
+      } as CodeBlock,
+    ];
+    const actualOutput = stringToMessageBlocks(input);
+    assert.deepStrictEqual(actualOutput, expectedOutput);
+  });
+
+  test("stringMessageBlocks shoudd throw an error if the number of code fences is odd", () => {
+    const input =
+      "Words here!\n```python\n    print('Hello, world!')\n```\nMore words here!\n```";
+    assert.throws(() => stringToMessageBlocks(input));
+  });
+
+  test("stringMessageBlocks should throw an error if only one code fence is present", () => {
+    const input = "```python\n    print('Hello, world!')\n";
+    assert.throws(() => stringToMessageBlocks(input));
+  });
+
+  test("stringMessageBlocks should throw an error if give only a code fence", () => {
+    const input = "```";
+    assert.throws(() => stringToMessageBlocks(input));
+  });
+
+  test("stringMessageBlocks should handle a single code block with no language identifier", () => {
+    const input = "```\n    print('Hello, world!')\n```";
+    const expectedOutput: MessageBlock[] = [
+      {
+        type: "code",
+        content: "    print('Hello, world!')",
+        languageId: undefined,
+      } as CodeBlock,
+    ];
+    const actualOutput = stringToMessageBlocks(input);
+    assert.deepStrictEqual(actualOutput, expectedOutput);
+  });
+
+  test("stringMessageBlocks should handle multiple text and code blocks", () => {
+    const input =
+      "Words here!\n```python\n    print('Hello, world!')\n```\nMore words here!\n```\n    print('Goodbye, world!')\n    print('Actually, hello again!)\n```";
+    const expectedOutput: MessageBlock[] = [
+      { type: "text", content: "Words here!" } as TextBlock,
+      {
+        type: "code",
+        content: "    print('Hello, world!')",
+        languageId: "python",
+      } as CodeBlock,
+      { type: "text", content: "More words here!" } as TextBlock,
+      {
+        type: "code",
+        content:
+          "    print('Goodbye, world!')\n    print('Actually, hello again!)",
+        languageId: undefined,
+      } as CodeBlock,
+    ];
+    const actualOutput = stringToMessageBlocks(input);
+    assert.deepStrictEqual(actualOutput, expectedOutput);
   });
 });


### PR DESCRIPTION
Switches to using markdown formatted API requests/responses, updating the prompt, and parsing to/from `Conversation`/`ChatMessage` correctly. Includes some tests I used in development, so I figured I'd leave those in.



Closes #76 