### PR TITLE
Show error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-byolad",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-byolad",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@google-ai/generativelanguage": "^1.0.1",
@@ -19,7 +19,7 @@
         "@types/vscode": "^1.81.0",
         "@typescript-eslint/eslint-plugin": "^6.6.0",
         "@typescript-eslint/parser": "^6.6.0",
-        "@vscode/test-electron": "^2.3.4",
+        "@vscode/test-electron": "^2.3.8",
         "@vscode/vsce": "^2.21.1",
         "eslint": "^8.47.0",
         "eslint-config-prettier": "^9.0.0",
@@ -627,9 +627,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.4.tgz",
-      "integrity": "sha512-eWzIqXMhvlcoXfEFNWrVu/yYT5w6De+WZXR/bafUQhAp8+8GkQo95Oe14phwiRUPv8L+geAKl/QM2+PoT3YW3g==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "@types/vscode": "^1.81.0",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
-    "@vscode/test-electron": "^2.3.4",
+    "@vscode/test-electron": "^2.3.8",
     "@vscode/vsce": "^2.21.1",
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^9.0.0",

--- a/src/helpers/sendChatMessage.ts
+++ b/src/helpers/sendChatMessage.ts
@@ -48,8 +48,7 @@ export async function sendChatMessage(
       handleErrorResponse(response, chatWebviewProvider);
     }
   } catch (error) {
-    console.error("Error occurred:", error);
-    vscode.window.showErrorMessage(`Unexpected error: ${error}`);
+    chatWebviewProvider.showErrorMessage(`Unexpected error: ${error}`);
   }
 }
 
@@ -76,11 +75,10 @@ function handleSuccessfulResponse(
 }
 
 /**
- * TODO: How to handle all of these? Probably depends on how the webview sidepanel is implemented.
+ * Handle a failed response from the chat model. Show an error message on the side panel with no change to the conversation.
  *
- * @param response
- * @param conversation
- * @param conversationManager
+ * @param response Response from the chat model
+ * @param chatWebviewProvider Current side panel
  */
 function handleErrorResponse(
   response: ChatModelResponse,
@@ -88,16 +86,15 @@ function handleErrorResponse(
 ): void {
   if (!response.success) {
     if (response.errorMessage) {
-      vscode.window.showErrorMessage(`Error: ${response.errorMessage}`);
+      chatWebviewProvider.showErrorMessage(`Error: ${response.errorMessage}`);
     } else {
-      vscode.window.showErrorMessage("Unknown error");
+      chatWebviewProvider.showErrorMessage("Unknown error");
     }
   } else if (!response.message) {
-    vscode.window.showErrorMessage(
+    chatWebviewProvider.showErrorMessage(
       "Response marked successful, but no message was returned",
     );
   } else {
-    vscode.window.showErrorMessage("Unknown error");
+    chatWebviewProvider.showErrorMessage("Unknown error");
   }
-  chatWebviewProvider.sendErrorResponse();
 }

--- a/src/providers/ChatViewProvider.ts
+++ b/src/providers/ChatViewProvider.ts
@@ -96,13 +96,16 @@ export class ChatWebviewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  public sendErrorResponse() {
+  public showErrorMessage(errorMessage: string) {
     if (!this._webviewView) {
-      vscode.window.showErrorMessage("No active webview view"); // How to handle?
+      vscode.window.showErrorMessage(errorMessage);
       return;
     }
     this._webviewView.webview.postMessage({
       messageType: "errorResponse",
+      params: {
+        errorMessage: errorMessage,
+      },
     });
   }
 

--- a/webview-ui/src/App.css
+++ b/webview-ui/src/App.css
@@ -50,7 +50,7 @@
 
 /* Styles the text and content below the nav bar */
 .App-body {
-  font-size: calc(8px + 2vmin);
+  font-size: var(--vscode-editor-font-size);
   /* Vertical offset of the body to render below the navbar.
      Also ensures that the edges of body content (e.g., the user icon)
      don't peek out from the edges of the navbar
@@ -61,14 +61,11 @@
 /* Chat Bar Styling Below */
 /* styles the box around the chat bar not including the buttons below */
 .chat-box {
-  padding-left: 5%;
-  padding-right: 5%;
   min-height: 9vh;
 }
 
 .chat-bar {
   background-color: #717171;
-  width: 100%;
   display: flex;
   align-items: center;
   border-radius: 60px;
@@ -93,7 +90,6 @@
 .message {
   padding-top: 10px;
   padding-bottom: 10px;
-  font-size: 0.9rem;
 }
 
 .role-name {

--- a/webview-ui/src/App.css
+++ b/webview-ui/src/App.css
@@ -157,3 +157,15 @@
   justify-content: center;
   padding-bottom: 4px;
 }
+
+.error-message-container {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 3px 0;
+  color: var(--vscode-problemsErrorIcon-foreground);
+}
+
+.warning-error-icon {
+  padding-right: 5px;
+}

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -6,6 +6,7 @@ import {
   ExtensionToWebviewMessage,
   UpdateConversationMessageParams,
   UpdateConversationListMessageParams,
+  ErrorResponseMessageParams,
 } from "./utilities/ExtensionToWebviewMessage";
 import { ChatView } from "./components/ChatView";
 import { ChatList } from "./components/ChatList";
@@ -20,6 +21,7 @@ function App() {
   );
   const [activeChat, setActiveChat] = useState<Conversation | null>(null);
   const [loadingMessage, setLoadingMessage] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const extensionMessenger = new ExtensionMessenger();
   const imagePaths: ImagePaths = window.initialState?.imagePaths;
@@ -46,6 +48,7 @@ function App() {
   const changeActiveChat = (conversation: Conversation | null) => {
     extensionMessenger.setActiveChat(conversation);
     setActiveChat(conversation);
+    setErrorMessage(null);
   };
 
   if (fetchConversations) {
@@ -79,6 +82,7 @@ function App() {
           }
         }
         setLoadingMessage(false);
+        setErrorMessage(null);
         break;
       }
       case "updateConversationList": {
@@ -88,7 +92,9 @@ function App() {
         break;
       }
       case "errorResponse": {
+        const params = message.params as ErrorResponseMessageParams;
         setLoadingMessage(false);
+        setErrorMessage(params.errorMessage);
         break;
       }
       default:
@@ -107,6 +113,7 @@ function App() {
           imagePaths={imagePaths}
           loadingMessage={loadingMessage}
           setLoadingMessage={setLoadingMessage}
+          errorMessage={errorMessage}
         />
       ) : chatList ? (
         // When there is no active chat, show the list of chats

--- a/webview-ui/src/components/ChatView.tsx
+++ b/webview-ui/src/components/ChatView.tsx
@@ -5,6 +5,7 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { VSCodeBadge } from "@vscode/webview-ui-toolkit/react";
 import { Message } from "./Message";
 import { ImagePaths } from "../types";
+import ErrorMessage from "./ErrorMessage";
 
 interface ChatViewProps {
   activeChat: Conversation;
@@ -12,6 +13,7 @@ interface ChatViewProps {
   imagePaths: ImagePaths;
   loadingMessage: boolean;
   setLoadingMessage: (loading: boolean) => void;
+  errorMessage: string | null;
 }
 
 export const ChatView = ({
@@ -20,6 +22,7 @@ export const ChatView = ({
   imagePaths,
   loadingMessage,
   setLoadingMessage,
+  errorMessage,
 }: ChatViewProps) => {
   const [userPrompt, setUserPrompt] = useState("");
 
@@ -162,9 +165,10 @@ export const ChatView = ({
       <div className="App-body">
         <div>{welcomeMessage}</div>
         <div>{messages}</div>
+        {loadingMessage === true && <p>Loading...</p>}
+        {errorMessage && <ErrorMessage errorMessage={errorMessage} />}
       </div>
       <footer className="App-footer">
-        {loadingMessage === true && <p>Loading...</p>}
         <div className="chat-box">
           <form
             className="chat-bar"

--- a/webview-ui/src/components/ErrorMessage.tsx
+++ b/webview-ui/src/components/ErrorMessage.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface ErrorMessageProps {
+  errorMessage: string;
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ errorMessage }) => {
+  return (
+    <div className="error-message-container">
+      <i className="codicon codicon-warning warning-error-icon"></i>
+      <p>{errorMessage}</p>
+    </div>
+  );
+};
+
+export default ErrorMessage;

--- a/webview-ui/src/utilities/ExtensionToWebviewMessage.ts
+++ b/webview-ui/src/utilities/ExtensionToWebviewMessage.ts
@@ -19,3 +19,7 @@ export interface UpdateConversationListMessageParams {
 export interface AddCodeBlockMessageParams {
   codeBlock: CodeBlock;
 }
+
+export interface ErrorResponseMessageParams {
+  errorMessage: string;
+}


### PR DESCRIPTION
The error messages that used to be displayed in pop-up notifications are now visible in the webview. They disappear when the user sends a message or navigates to a different chat.

![image](https://github.com/beanlab/byoLAD/assets/66281828/afa640ec-1224-4f9c-8ba8-b50806af1d63)