### PR TITLE
Add to Chat vs Add to New Chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
         "command": "vscode-byolad.addCodeToChat",
         "title": "byoLAD — Add Code to Chat",
         "category": "byoLAD"
+      },
+      {
+        "command": "vscode-byolad.addCodeToNewChat",
+        "title": "byoLAD — Add Code to New Chat",
+        "category": "byoLAD"
       }
     ],
     "menus": {
@@ -151,7 +156,11 @@
         },
         {
           "command": "vscode-byolad.addCodeToChat",
-          "when": "editorFocus"
+          "when": "editorFocus && view.vscode-byolad.chat.visible && vscode-byolad.hasActiveChat"
+        },
+        {
+          "command": "vscode-byolad.addCodeToNewChat",
+          "when": "editorFocus && (!view.vscode-byolad.chat.visible || !vscode-byolad.hasActiveChat)"
         },
         {
           "command": "vscode-byolad.deleteAllChats"
@@ -159,8 +168,13 @@
       ],
       "editor/context": [
         {
-          "when": "editorFocus",
+          "when": "editorFocus && view.vscode-byolad.chat.visible && vscode-byolad.hasActiveChat",
           "command": "vscode-byolad.addCodeToChat",
+          "group": "1_modification"
+        },
+        {
+          "when": "editorFocus && (!view.vscode-byolad.chat.visible || !vscode-byolad.hasActiveChat)",
+          "command": "vscode-byolad.addCodeToNewChat",
           "group": "1_modification"
         }
       ]

--- a/src/Chat/ChatManager.ts
+++ b/src/Chat/ChatManager.ts
@@ -3,6 +3,7 @@ import { ExtensionContext } from "vscode";
 import { ChatMessage } from "../ChatModel/ChatModel";
 import * as constants from "../commands/constants";
 import { SettingsProvider } from "../helpers/SettingsProvider";
+import { setHasActiveChatWhenClauseState } from "../helpers";
 
 /**
  * Manages the chat history and the active chat in the VS Code workspace state.
@@ -49,9 +50,15 @@ export class ChatManager {
   }
 
   set activeChatId(value: number | null) {
-    if (value && !this.chatIds.includes(value)) {
+    if (!value) {
+      setHasActiveChatWhenClauseState(false);
+    } else if (!this.chatIds.includes(value)) {
+      setHasActiveChatWhenClauseState(false);
       throw new Error("Chat ID does not exist");
+    } else {
+      setHasActiveChatWhenClauseState(true);
     }
+
     this.context.workspaceState.update(constants.ACTIVE_CHAT_ID_KEY, value);
   }
 

--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -16,6 +16,9 @@ export const CHAT_IDS_KEY = "chatIds"; // Do not change without handling migrati
 export const ACTIVE_CHAT_ID_KEY = "activeChatId"; // Do not change without handling migration
 export const NEXT_ID_KEY = "nextId"; // Do not change without handling migration
 
+// "when" clause keys
+export const HAS_ACTIVE_CHAT_WHEN_CLAUSE_KEY = "vscode-byolad.hasActiveChat";
+
 // Settings/configuration error messages
 export const MODEL_NOT_SET_ERROR_MESSAGE =
   "Model not set. Please set a model for the byoLAD extension.";

--- a/src/commands/getAddCodeToChatCommand.ts
+++ b/src/commands/getAddCodeToChatCommand.ts
@@ -1,59 +1,18 @@
 import * as vscode from "vscode";
 import { ChatManager } from "../Chat/ChatManager";
 import { ChatWebviewProvider } from "../providers/ChatViewProvider";
-import { getCodeReference } from "../helpers/getCodeReference";
-import { ChatRole, CodeBlock, MessageBlock } from "../ChatModel/ChatModel";
-import { ensureActiveWebviewAndChat } from "../helpers/ensureActiveWebviewAndChat";
+import { addSelectedCodeToChat } from "../helpers/addSelectedCodeToChat";
 
 /**
  * Command to add the selected code (or whole file if no selection) to the active chat.
  * Opens webview and/or starts chat if necessary.
  */
+
 export const getAddCodeToChatCommand = (
   chatWebviewProvider: ChatWebviewProvider,
   chatManager: ChatManager,
 ) =>
   vscode.commands.registerCommand("vscode-byolad.addCodeToChat", async () => {
-    await ensureActiveWebviewAndChat(chatManager, chatWebviewProvider);
-
-    const activeChatId = chatManager.activeChatId;
-    if (activeChatId) {
-      const activeChat = chatManager.getChat(activeChatId);
-      if (activeChat) {
-        const activeEditor = vscode.window.activeTextEditor;
-        if (activeEditor) {
-          const codeBlock = getCodeReference(activeEditor) as CodeBlock | null;
-          if (codeBlock) {
-            const updatedChat = { ...activeChat };
-            let lastMessage;
-
-            if (!updatedChat.messages || updatedChat.messages.length === 0) {
-              updatedChat.messages = [];
-              const newMessage = {
-                role: ChatRole.User,
-                content: [] as MessageBlock[],
-              };
-              updatedChat.messages.push(newMessage);
-              lastMessage = newMessage;
-            } else {
-              lastMessage =
-                updatedChat.messages[updatedChat.messages.length - 1];
-            }
-
-            if (lastMessage.role === ChatRole.User) {
-              lastMessage.content.push(codeBlock);
-            } else {
-              const newMessage = {
-                role: ChatRole.User,
-                content: [codeBlock] as MessageBlock[],
-              };
-              updatedChat.messages.push(newMessage);
-            }
-
-            chatManager.updateChat(updatedChat);
-            chatWebviewProvider.updateChat(chatManager.chats, updatedChat.id);
-          }
-        }
-      }
-    }
+    addSelectedCodeToChat(chatManager, chatWebviewProvider);
+    chatWebviewProvider.updateChat(chatManager.chats, chatManager.activeChatId);
   });

--- a/src/commands/getAddCodeToNewChatCommand.ts
+++ b/src/commands/getAddCodeToNewChatCommand.ts
@@ -1,0 +1,18 @@
+import * as vscode from "vscode";
+import { ChatManager } from "../Chat/ChatManager";
+import { ChatWebviewProvider } from "../providers/ChatViewProvider";
+import { addSelectedCodeToChat } from "../helpers/addSelectedCodeToChat";
+
+export const getAddCodeToNewChatCommand = (
+  chatWebviewProvider: ChatWebviewProvider,
+  chatManager: ChatManager,
+) =>
+  vscode.commands.registerCommand(
+    "vscode-byolad.addCodeToNewChat",
+    async () => {
+      const activeChat = chatManager.startChat("Code Chat"); // TODO: How to name?
+      addSelectedCodeToChat(chatManager, chatWebviewProvider);
+      await vscode.commands.executeCommand("vscode-byolad.chat.focus");
+      chatWebviewProvider.updateChat(chatManager.chats, activeChat.id);
+    },
+  );

--- a/src/commands/getNewChatCommand.ts
+++ b/src/commands/getNewChatCommand.ts
@@ -12,6 +12,7 @@ export const getNewChatCommand = (
   chatViewProvider: ChatWebviewProvider,
 ): vscode.Disposable => {
   return vscode.commands.registerCommand("vscode-byolad.newChat", async () => {
+    await vscode.commands.executeCommand("vscode-byolad.chat.focus");
     const activeChat = chatManager.startChat("Code Chat"); // TODO: How to name?
     chatViewProvider.updateChat(chatManager.chats, activeChat.id);
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { getOpenSettingsCommand } from "./commands/getOpenSettingsCommand";
 import { ChatWebviewProvider } from "./providers/ChatViewProvider";
 import { getAddCodeToNewChatCommand } from "./commands/getAddCodeToNewChatCommand";
 import { getAddCodeToChatCommand } from "./commands/getAddCodeToChatCommand";
+import { setHasActiveChatWhenClauseState } from "./helpers";
 
 export function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration("vscode-byolad");
@@ -23,6 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
     settingsProvider,
     chatManager,
   );
+
+  setHasActiveChatWhenClauseState(!!chatManager.activeChatId);
 
   const chatViewDisposable = vscode.window.registerWebviewViewProvider(
     ChatWebviewProvider.viewType,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { getDeleteChatCommand } from "./commands/getDeleteChatCommand";
 import { getExplainCodeCommand } from "./commands/getExplainCodeCommand";
 import { getOpenSettingsCommand } from "./commands/getOpenSettingsCommand";
 import { ChatWebviewProvider } from "./providers/ChatViewProvider";
+import { getAddCodeToNewChatCommand } from "./commands/getAddCodeToNewChatCommand";
 import { getAddCodeToChatCommand } from "./commands/getAddCodeToChatCommand";
 
 export function activate(context: vscode.ExtensionContext) {
@@ -60,6 +61,10 @@ export function activate(context: vscode.ExtensionContext) {
     chatWebviewProvider,
     chatManager,
   );
+  const addCodeToNewChatCommand = getAddCodeToNewChatCommand(
+    chatWebviewProvider,
+    chatManager,
+  );
   const openSettingsCommand = getOpenSettingsCommand();
 
   const onDidChangeConfigurationHandler =
@@ -80,6 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
     reviewCodeTextDocumentContentProvider,
     chatViewDisposable,
     addCodeToChatCommand,
+    addCodeToNewChatCommand,
   );
 }
 

--- a/src/helpers/addSelectedCodeToChat.ts
+++ b/src/helpers/addSelectedCodeToChat.ts
@@ -1,0 +1,47 @@
+import * as vscode from "vscode";
+import { ChatManager } from "../Chat/ChatManager";
+import { ChatWebviewProvider } from "../providers/ChatViewProvider";
+import { getCodeReference } from "./getCodeReference";
+import { ChatRole, CodeBlock, MessageBlock } from "../ChatModel/ChatModel";
+
+export function addSelectedCodeToChat(
+  chatManager: ChatManager,
+  chatWebviewProvider: ChatWebviewProvider,
+) {
+  console.log(chatWebviewProvider);
+  const activeChat = chatManager.getActiveChat();
+  if (activeChat) {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) {
+      const codeBlock = getCodeReference(activeEditor) as CodeBlock | null;
+      if (codeBlock) {
+        const updatedChat = { ...activeChat };
+        let lastMessage;
+
+        if (!updatedChat.messages || updatedChat.messages.length === 0) {
+          updatedChat.messages = [];
+          const newMessage = {
+            role: ChatRole.User,
+            content: [] as MessageBlock[],
+          };
+          updatedChat.messages.push(newMessage);
+          lastMessage = newMessage;
+        } else {
+          lastMessage = updatedChat.messages[updatedChat.messages.length - 1];
+        }
+
+        if (lastMessage.role === ChatRole.User) {
+          lastMessage.content.push(codeBlock);
+        } else {
+          const newMessage = {
+            role: ChatRole.User,
+            content: [codeBlock] as MessageBlock[],
+          };
+          updatedChat.messages.push(newMessage);
+        }
+
+        chatManager.updateChat(updatedChat);
+      }
+    }
+  }
+}

--- a/src/helpers/ensureActiveWebviewAndChat.ts
+++ b/src/helpers/ensureActiveWebviewAndChat.ts
@@ -6,7 +6,7 @@ import { ChatManager } from "../Chat/ChatManager";
 /**
  * Makes sure there is an active chat in the open webview panel.
  * If there is no open webview panel, it is opened and a new chat is created.
- * Or, if there is no active chat, a new one is created.
+ * Or, if there is an open webview panel but there is no active chat, a new one is created.
  *
  * @param chatManager
  * @param chatWebviewProvider
@@ -16,11 +16,10 @@ export async function ensureActiveWebviewAndChat(
   chatWebviewProvider: ChatWebviewProvider,
 ) {
   if (!chatWebviewProvider.isWebviewVisible()) {
-    await vscode.commands.executeCommand("vscode-byolad.newChat");
     // Built-in webview command to open the webview
     await vscode.commands.executeCommand("vscode-byolad.chat.focus");
-  }
-  if (!chatManager.getActiveChat()) {
+    await vscode.commands.executeCommand("vscode-byolad.newChat");
+  } else if (!chatManager.getActiveChat()) {
     await vscode.commands.executeCommand("vscode-byolad.newChat");
   }
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -4,3 +4,4 @@ export {
 } from "./getDocumentTextAroundSelection";
 export { injectChatModel } from "./injectChatModel";
 export { getReviewCodeTextDocumentContentProvider } from "./getReviewCodeTextDocumentContentProvider";
+export { setHasActiveChatWhenClauseState } from "./setHasActiveChatWhenClauseState";

--- a/src/helpers/setHasActiveChatWhenClauseState.ts
+++ b/src/helpers/setHasActiveChatWhenClauseState.ts
@@ -1,0 +1,10 @@
+import * as vscode from "vscode";
+import * as constants from "../commands/constants";
+
+export function setHasActiveChatWhenClauseState(hasActiveChat: boolean) {
+  vscode.commands.executeCommand(
+    "setContext",
+    constants.HAS_ACTIVE_CHAT_WHEN_CLAUSE_KEY,
+    hasActiveChat,
+  );
+}

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -63,19 +63,16 @@ function App() {
     switch (message.messageType) {
       case "updateChat": {
         const params = message.params as UpdateChatMessageParams;
-        const chats = params.chats;
-        const activeChatId = params.activeChatId;
-        setChatList(chats);
-        if (activeChatId) {
-          const activeChat =
-            chats.find((chat) => chat.id === activeChatId) || null;
-          setActiveChat(activeChat);
-        } else if (activeChat) {
-          const newActiveChat = chats.find((chat) => chat.id === activeChat.id);
-          if (newActiveChat) {
-            setActiveChat(newActiveChat);
-          }
+
+        setChatList(params.chats);
+
+        if (params.activeChatId) {
+          const newActiveChat: Chat | null =
+            params.chats.find((chat) => chat.id === params.activeChatId) ||
+            null;
+          setActiveChat(newActiveChat);
         }
+
         setLoadingMessage(false);
         setErrorMessage(null);
         break;

--- a/webview-ui/src/components/ChatList.tsx
+++ b/webview-ui/src/components/ChatList.tsx
@@ -31,17 +31,20 @@ export const ChatList = ({ chatList, changeActiveChat }: ChatListProps) => {
   };
 
   const listOfChats = chatList.map((chat) => {
-    let name = chat.name;
-    if (chat.messages.length === 0) {
-      name = "Empty Chat";
-    } else if (chat.messages[0].content[0].type !== "code") {
-      name = chat.messages[0].content[0].content;
-    } else {
-      name = "undefined";
-      const temp = chat.messages[1].content[0].content;
-      const temp2 = temp.split(".");
-      name = temp2[0];
-    }
+    console.log("chat: ", chat);
+    const name = chat.name;
+    // TODO: Change how chat names are defined and displayed
+    // if (chat.messages.length === 0) {
+    //   name = "Empty Chat";
+    // } else if (chat.messages[0].content[0].type !== "code") {
+    //   name = chat.messages[0].content[0].content;
+    // } else {
+    //   name = "undefined";
+    //   console.log("chat.messages[1].content[0].content: ", chat.messages[1].content[0].content)
+    //   const temp = chat.messages[1].content[0].content;
+    //   const temp2 = temp.split(".");
+    //   name = temp2[0];
+    // }
     return (
       <div className="convo">
         <div


### PR DESCRIPTION
The context menu option "add code to chat" now has a distinction between adding to the current chat and adding to a new chat. A [custom when clause context](https://code.visualstudio.com/api/references/when-clause-contexts#add-a-custom-when-clause-context) allows the context menu to only show on of those commands at a time.

Updated functionality:
- If the webview is not visible, then the "Add Code to New Chat" command is available, which opens a new chat, adds the code, and makes the webview visible.
- If the webview is visible but there is no active chat, then the "Add Code to New Chat" command is available, which opens a new chat and adds the code.
- If the webview is visible and there is an active chat, then the "Add Code to Chat" command is available, which only adds the code.