### PR TITLE
Chat identification: title updates, added tags for file and persona name

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,1 @@
+bash: 2: command not found

--- a/shared/types/Chat.ts
+++ b/shared/types/Chat.ts
@@ -18,4 +18,5 @@ export interface Chat {
    * User-facing title/name
    */
   title: string;
+  tags: string[];
 }

--- a/src/Chat/ChatDataManager.ts
+++ b/src/Chat/ChatDataManager.ts
@@ -123,6 +123,7 @@ export class ChatDataManager {
         this.settingsProvider.getBasePromptInstruction() +
         constants.LLM_MESSAGE_FORMATTING_INSTRUCTION,
       title: "Empty Chat",
+      tags: []
     };
     return chat;
   }

--- a/src/helpers/getCurrentOpenFileName.ts
+++ b/src/helpers/getCurrentOpenFileName.ts
@@ -1,0 +1,12 @@
+import * as vscode from "vscode";
+
+
+export function getCurrentOpenFileName(): string | undefined {
+  try {
+    const currentlyOpenTabfilePath = vscode.window.activeTextEditor?.document.fileName;
+    const filename = currentlyOpenTabfilePath?.replace(/^.*[\\/]/, '')
+    return filename
+  } catch (error) {
+    vscode.window.showErrorMessage(`Failed to get file name: ${error}`);
+  }
+}

--- a/src/helpers/sendChatMessage.ts
+++ b/src/helpers/sendChatMessage.ts
@@ -10,6 +10,7 @@ import { ChatDataManager } from "../Chat/ChatDataManager";
 import { LLMApiService } from "../ChatModel/LLMApiService";
 import { ChatWebviewProvider } from "../webview/ChatWebviewProvider";
 import { stringToMessageBlocks } from "../../shared/utils/messageBlockHelpers";
+import { getCurrentOpenFileName } from "./getCurrentOpenFileName";
 
 /**
  * Primary function to send a chat message. Starts a new chat if needed,
@@ -59,6 +60,17 @@ export async function sendChatMessage(
     messageBlocks.push(codeBlock);
   }
 
+  // if this is the first time a message is sent, then update the chat title
+  if (chat.title == "Empty Chat"){
+    chat.title = markdown 
+  }
+
+  // if the file is a new file, add it to the tags
+  const openedFileName = getCurrentOpenFileName() 
+    if ((openedFileName !== undefined) && !chat.tags.includes(openedFileName)){
+      chat.tags.push(openedFileName)
+    }
+  
   // Update the webview, chat itself, and send the message to the LLM API
   await extensionToWebviewMessageSender.updateIsMessageLoading(true);
   await chatEditor.appendMessageBlocks(chat, ChatRole.User, messageBlocks);

--- a/webview-ui/src/App.css
+++ b/webview-ui/src/App.css
@@ -137,6 +137,7 @@
 }
 
 .convo-id {
+  font-size: 1.2em;
   padding-right: 20px;
   cursor: pointer;
   padding-top: 10px;
@@ -159,3 +160,25 @@
 .warning-error-icon {
   padding-right: 5px;
 }
+
+.file-tags {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 70%;
+}
+
+.file-tag {
+  display: flex;
+  margin: 3px
+}
+
+.persona-tag {
+  display: flex;
+  margin: 3px
+}
+
+.tags {
+  display: flex;
+  justify-content: space-between;    /* Add this */
+}
+

--- a/webview-ui/src/components/ChatListView/ChatInChatList.tsx
+++ b/webview-ui/src/components/ChatListView/ChatInChatList.tsx
@@ -1,5 +1,5 @@
 import { Chat } from "../../../../shared/types";
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeButton, VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 import { useState } from "react";
 import { useExtensionMessageContext } from "../../utilities/ExtensionMessageContext";
 
@@ -31,42 +31,57 @@ export const ChatInChatList = ({
   };
 
   return (
-    <div className="convo" key={id}>
-      {editing ? (
-        <input value={title} onChange={handleInputChange} />
-      ) : (
-        <div onClick={() => handleClick(chat)} className="convo-id">
-          {chat.title}
-        </div>
-      )}
-      <div>
+    <div>
+      <div className="convo" key={id}>
         {editing ? (
-          <VSCodeButton
-            appearance="icon"
-            aria-label="Done editing chat title"
-            title="Done editing chat title"
-            onClick={() => handleEditClick()}
-          >
-            <i className="codicon codicon-check"></i>
-          </VSCodeButton>
+          <input value={title} onChange={handleInputChange} />
         ) : (
+          <div onClick={() => handleClick(chat)} className="convo-id">
+            {chat.title}
+          </div>
+        )}
+        <div>
+          {editing ? (
+            <VSCodeButton
+              appearance="icon"
+              aria-label="Done editing chat title"
+              title="Done editing chat title"
+              onClick={() => handleEditClick()}
+            >
+              <i className="codicon codicon-check"></i>
+            </VSCodeButton>
+          ) : (
+            <VSCodeButton
+              appearance="icon"
+              aria-label="Edit chat title"
+              title="Edit chat title"
+              onClick={() => handleEditClick()}
+            >
+              <i className="codicon codicon-edit"></i>
+            </VSCodeButton>
+          )}
           <VSCodeButton
             appearance="icon"
-            aria-label="Edit chat title"
-            title="Edit chat title"
-            onClick={() => handleEditClick()}
+            aria-label="Delete chat"
+            title="Delete chat"
+            onClick={() => deleteChat(chat.id)}
           >
-            <i className="codicon codicon-edit"></i>
+            <i className="codicon codicon-trash"></i>
           </VSCodeButton>
-        )}
-        <VSCodeButton
-          appearance="icon"
-          aria-label="Delete chat"
-          title="Delete chat"
-          onClick={() => deleteChat(chat.id)}
-        >
-          <i className="codicon codicon-trash"></i>
-        </VSCodeButton>
+        </div>
+      </div>
+      
+      <div className="tags">
+          <div className="file-tags">
+            {chat.tags.map((tagName,i)=>(
+              <div className="file-tag">
+                <VSCodeTag  key={i}>{tagName}</VSCodeTag>
+              </div>
+            ))}
+        </div>
+        <div className='persona-tag'>
+          <VSCodeTag>Persona name</VSCodeTag>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Title now updates from "empty chat" to whatever the first message the user sent was
Tags are added to the chat list view for each file the chat is associated with
There is a persona tag (just UI)
Increased chat title size to compensate for tag size
<img width="283" alt="image" src="https://github.com/beanlab/byoLAD/assets/95512267/7089cb31-4585-4d47-aec8-8a6455dea0fe">

