### PR TITLE
Bug fixes

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,1 @@
+bash: 2: command not found

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@google-ai/generativelanguage": "^1.0.1",
+        "@vscode/codicons": "^0.0.35",
         "autosize": "^6.0.1",
         "google-auth-library": "^9.0.0",
         "openai": "^4.5.0",
@@ -634,6 +635,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.35.tgz",
+      "integrity": "sha512-7iiKdA5wHVYSbO7/Mm0hiHD3i4h+9hKUe1O4hISAe/nHhagMwb2ZbFC8jU6d7Cw+JNT2dWXN2j+WHbkhT5/l2w=="
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
   "dependencies": {
     "@google-ai/generativelanguage": "^1.0.1",
     "autosize": "^6.0.1",
+    "@vscode/codicons": "^0.0.35",
     "google-auth-library": "^9.0.0",
     "openai": "^4.5.0",
     "scroll-into-view-if-needed": "^3.1.0"

--- a/shared/types/Persona.ts
+++ b/shared/types/Persona.ts
@@ -1,3 +1,4 @@
+// import { STANDARD_PERSONAS } from "../data/StandardPersonas";
 import { ModelProvider } from "./";
 
 /**
@@ -45,6 +46,7 @@ type ValidationRule = (value: string) => string | null;
 
 export function validatePersonaDraftProperties(
   persona: PersonaDraft,
+  currPersonaNames: string[]
 ): Map<keyof PersonaDraft, string> {
   const errors = new Map<keyof PersonaDraft, string>();
 
@@ -56,6 +58,7 @@ export function validatePersonaDraftProperties(
       fieldMissing,
       isEmptyOrWhitespace,
       isGreaterThanMaxLength(PERSONA_NAME_MAX_LENGTH),
+      duplicateName(currPersonaNames)
     ],
     errors,
   );
@@ -137,9 +140,16 @@ const isGreaterThanMaxLength =
       ? `cannot be longer than ${maxLength} characters`
       : null;
 
-const fieldMissing: ValidationRule = (value) => (!value ? "is required" : null);
+const fieldMissing: ValidationRule = (value:string) => (!value ? "is required" : null);
 
 const isInvalidModelProvider: ValidationRule = (value: string) =>
   !Object.values(ModelProvider).includes(value as ModelProvider)
     ? "is not a supported model provider"
     : null;
+
+const duplicateName =
+  (currPersonaNames: string[]): ValidationRule =>
+  (value) =>
+    currPersonaNames.includes(value)
+      ? `"${value}" is the name of an existing persona`
+      : null;

--- a/src/Chat/ChatDataManager.ts
+++ b/src/Chat/ChatDataManager.ts
@@ -13,6 +13,7 @@ export class ChatDataManager {
   private readonly context: ExtensionContext;
   private readonly settingsProvider: SettingsProvider;
   private readonly personaDataManager: PersonaDataManager;
+  public readonly DEFAULT_CHAT_NAME: string = "Empty Chat";
 
   constructor(
     context: ExtensionContext,
@@ -128,7 +129,7 @@ export class ChatDataManager {
       id: newId,
       messages: messages ?? [],
       personaId: this.personaDataManager.defaultPersonaId,
-      title: "Empty Chat",
+      title: this.DEFAULT_CHAT_NAME,
       tags: [],
     };
     return chat;

--- a/src/Persona/PersonaDataManager.ts
+++ b/src/Persona/PersonaDataManager.ts
@@ -138,7 +138,7 @@ export class PersonaDataManager {
       description: draft.description,
       instructions: draft.instructions,
       modelProvider: draft.modelProvider,
-      modelId: draft.modelId,
+      modelId: draft.modelId.trim()  
     };
     this.nextId++;
     this.personas = [...this.personas, newPersona];

--- a/src/Persona/PersonaDataManager.ts
+++ b/src/Persona/PersonaDataManager.ts
@@ -128,7 +128,7 @@ export class PersonaDataManager {
   addNewPersona(draft: PersonaDraft): Persona {
     this.validateNewPersonaName(draft.name);
     const errorMessages: Map<keyof PersonaDraft, string> =
-      validatePersonaDraftProperties(draft);
+      validatePersonaDraftProperties(draft, this.personas.map((persona)=>persona.name));
     if (errorMessages.size) {
       throw new Error(`Invalid Persona: ${errorMapToString(errorMessages)}`);
     }

--- a/src/Persona/PersonaDataManager.ts
+++ b/src/Persona/PersonaDataManager.ts
@@ -128,7 +128,10 @@ export class PersonaDataManager {
   addNewPersona(draft: PersonaDraft): Persona {
     this.validateNewPersonaName(draft.name);
     const errorMessages: Map<keyof PersonaDraft, string> =
-      validatePersonaDraftProperties(draft, this.personas.map((persona)=>persona.name));
+      validatePersonaDraftProperties(
+        draft,
+        this.personas.map((persona) => persona.name),
+      );
     if (errorMessages.size) {
       throw new Error(`Invalid Persona: ${errorMapToString(errorMessages)}`);
     }
@@ -138,7 +141,7 @@ export class PersonaDataManager {
       description: draft.description,
       instructions: draft.instructions,
       modelProvider: draft.modelProvider,
-      modelId: draft.modelId.trim()  
+      modelId: draft.modelId.trim(),
     };
     this.nextId++;
     this.personas = [...this.personas, newPersona];

--- a/src/Persona/PersonaDataManager.ts
+++ b/src/Persona/PersonaDataManager.ts
@@ -188,8 +188,8 @@ export class PersonaDataManager {
     if (!name.trim()) {
       throw new Error("Persona name cannot be empty or whitespace");
     }
-    if (name.length > 25) {
-      throw new Error("Persona name cannot be more than 25 characters");
+    if (name.length >= 30) {
+      throw new Error("Persona name cannot be more than 30 characters");
     }
   }
 

--- a/src/helpers/sendChatMessage.ts
+++ b/src/helpers/sendChatMessage.ts
@@ -56,8 +56,8 @@ export async function sendChatMessage(
     messageBlocks.push(codeBlock);
   }
 
-  // if this is the first time a message is sent, then update the chat title
-  if (chat.messages.length == 0) {
+  // if it is still the default title, then update the chat title
+  if (chat.title == chatDataManager.DEFAULT_CHAT_NAME) {
     chat.title = markdown;
     chat.tags = [];
   }

--- a/webview-ui/src/App.css
+++ b/webview-ui/src/App.css
@@ -286,3 +286,7 @@
 code {
   background: none;
 }
+
+.persona-dropdown {
+  width: 220px;
+}

--- a/webview-ui/src/App.css
+++ b/webview-ui/src/App.css
@@ -288,5 +288,5 @@ code {
 }
 
 .persona-dropdown {
-  width: 220px;
+  width: 200px;
 }

--- a/webview-ui/src/App.css
+++ b/webview-ui/src/App.css
@@ -99,7 +99,7 @@
 
 .text-block-container {
   position: relative;
-  padding: 3px 0;
+  padding: 3px 10px 3px 0px;
   overflow-wrap: break-word;
 }
 

--- a/webview-ui/src/components/ChatListView/ChatInChatList.tsx
+++ b/webview-ui/src/components/ChatListView/ChatInChatList.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { KeyboardEvent } from "react";
 
 import {
   VSCodeButton,
@@ -59,6 +60,12 @@ export const ChatInChatList = ({
     }
   };
 
+  const handleKeywordKeyPress = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.key == "Enter") {
+      handleSaveClick();
+    }
+  };
+
   const allowedToEdit = () => {
     return currEditableIndex === null || currEditableIndex === index;
   };
@@ -70,6 +77,7 @@ export const ChatInChatList = ({
           <VSCodeTextField
             value={title}
             onInput={(e) => handleInputChange(e as InputEvent)}
+            onKeyDown={(e) => handleKeywordKeyPress(e)}
           />
         ) : (
           <div

--- a/webview-ui/src/components/ChatListView/ChatInChatList.tsx
+++ b/webview-ui/src/components/ChatListView/ChatInChatList.tsx
@@ -13,20 +13,37 @@ import { useExtensionMessageContext } from "../../utilities/ExtensionMessageCont
 
 interface ChatInChatListProps {
   chat: Chat;
+  onEdit: () => void;
+  onSave: () => void;
+  currEditableIndex: number | null;
+  index: number;
 }
 
-export const ChatInChatList = ({ chat }: ChatInChatListProps) => {
+export const ChatInChatList = ({
+  chat,
+  onEdit,
+  onSave,
+  currEditableIndex,
+  index,
+}: ChatInChatListProps) => {
   const { deleteChat, updateChat } = useExtensionMessageContext();
   const [editing, setEditing] = useState<boolean>(false);
   const [title, setTitle] = useState<string>(chat.title);
   const { navigate, personaList } = useAppContext();
 
   const handleEditClick = () => {
-    setEditing(!editing);
-    if (editing === true) {
-      chat.title = title;
-      updateChat(chat);
+    if (allowedToEdit()) {
+      onEdit();
+      setEditing(!editing);
     }
+  };
+
+  const handleSaveClick = () => {
+    chat.title = title;
+
+    updateChat(chat);
+    onSave();
+    setEditing(false);
   };
 
   const handleInputChange = (event: InputEvent) => {
@@ -35,6 +52,16 @@ export const ChatInChatList = ({ chat }: ChatInChatListProps) => {
 
   const getPersonaName = (personaId: number) =>
     personaList.find((p) => p.id === personaId)?.name;
+
+  const handleDeleteClick = (chatID: number) => {
+    if (allowedToEdit() && !editing) {
+      deleteChat(chatID);
+    }
+  };
+
+  const allowedToEdit = () => {
+    return currEditableIndex === null || currEditableIndex === index;
+  };
 
   return (
     <div>
@@ -59,7 +86,7 @@ export const ChatInChatList = ({ chat }: ChatInChatListProps) => {
               appearance="icon"
               aria-label="Done editing chat title"
               title="Done editing chat title"
-              onClick={() => handleEditClick()}
+              onClick={() => handleSaveClick()}
             >
               <i className="codicon codicon-check"></i>
             </VSCodeButton>
@@ -77,7 +104,7 @@ export const ChatInChatList = ({ chat }: ChatInChatListProps) => {
             appearance="icon"
             aria-label="Delete chat"
             title="Delete chat"
-            onClick={() => deleteChat(chat.id)}
+            onClick={() => handleDeleteClick(chat.id)}
           >
             <i className="codicon codicon-trash"></i>
           </VSCodeButton>

--- a/webview-ui/src/components/ChatListView/ChatList.tsx
+++ b/webview-ui/src/components/ChatListView/ChatList.tsx
@@ -1,17 +1,36 @@
+import { useState } from "react";
 import { Chat } from "../../../../shared/types";
 import Stack from "../Stack";
 import { ChatInChatList } from "./ChatInChatList";
+// import { ChatInChatList } from "./ChatInChatList";
 
 interface ChatListProps {
   chatList: Chat[];
 }
 
 export const ChatList = ({ chatList }: ChatListProps) => {
+
+  const [editableIndex, setEditableIndex] = useState<number | null>(null);
+
+  const listHandleEdit = (index: number) => {
+    setEditableIndex(index)
+  }
+
+  const listHandleSave = () => {
+    setEditableIndex(null);
+};
+
   return (
     <Stack>
       {chatList.length > 0 ? (
         chatList.map((chat: Chat, i: number) => (
-          <ChatInChatList chat={chat} key={i}></ChatInChatList>
+          <ChatInChatList 
+            chat={chat} 
+            onEdit={() => listHandleEdit(i)} 
+            onSave={() => listHandleSave()}
+            currEditableIndex={editableIndex}
+            index={i}
+          />
         ))
       ) : (
         <span>No chats found</span>

--- a/webview-ui/src/components/PersonaDropdown.tsx
+++ b/webview-ui/src/components/PersonaDropdown.tsx
@@ -21,7 +21,7 @@ export const PersonaDropdown: React.FC<PersonaDropdownProps> = ({
 
   return (
     <VSCodeDropdown
-      id="persona-dropdown"
+      className="persona-dropdown"
       onInput={handleOnPersonaSelect}
       value={selectedPersonaId.toString()} // Sets initial value
     >

--- a/webview-ui/src/components/SettingsView/EditPersona.tsx
+++ b/webview-ui/src/components/SettingsView/EditPersona.tsx
@@ -14,6 +14,7 @@ import {
   PersonaDraft,
   validatePersonaDraftProperties,
 } from "../../../../shared/types";
+import { useAppContext } from "../../utilities/AppContext";
 
 function getProviderModelUrl(provider: ModelProvider): string {
   switch (provider) {
@@ -46,6 +47,7 @@ export const EditPersona: React.FC<{
   onSave: (persona: Persona | PersonaDraft) => void;
   onCancel: () => void;
 }> = ({ persona: personaDraft, onSave, onCancel }) => {
+  const { personaList } = useAppContext();
   const [editedPersonaDraft, setEditedPersona] = useState(personaDraft);
   const [validationErrors, setValidationErrors] = useState<
     Map<keyof PersonaDraft, string>
@@ -56,11 +58,11 @@ export const EditPersona: React.FC<{
 
   // On mount, invalidates the input, which will keep the save button disabled if needed until the user makes a change
   useEffect(() => {
-    setValidationErrors(validatePersonaDraftProperties(editedPersonaDraft));
+    setValidationErrors(validatePersonaDraftProperties(editedPersonaDraft, personaList.map((persona)=>persona.name)));
   }, []);
 
   useEffect(() => {
-    setValidationErrors(validatePersonaDraftProperties(editedPersonaDraft));
+    setValidationErrors(validatePersonaDraftProperties(editedPersonaDraft, personaList.map((persona)=>persona.name)));
   }, [editedPersonaDraft]);
 
   const handleStringChange = (e: InputEvent) => {


### PR DESCRIPTION
Fixed the following bugs:
- Different valid name lengths (25 in one spot and 30 in another) -- Now, changed to all be 30 characters
- drop down persona names were getting cut off (changed the UI so it is now a consistent width)
![image](https://github.com/beanlab/byoLAD/assets/95512267/e25c1d01-b6c1-4201-be58-2d41a93d4d2c)
- Chat name was "Empty Chat" if the first block was a code block
- If there was whitespace after the model name when creating a persona, it would be invalid. 
- Duplicate persona name error didn't show up. Now, an error shows up and the user cannot create the person without changing the name. 
![image](https://github.com/beanlab/byoLAD/assets/95512267/d1ffc2cd-c7db-4c02-8e83-073c3f6c80ef)
- Now, cannot edit/delete other chats while editing a chat name
- Title now saves when pressing enter, rather than just the checkmark
- Delete icon hovers over text -- improvement (adjusted margin so it doesn't look as bad)
![image](https://github.com/beanlab/byoLAD/assets/95512267/ce4539d7-2de3-40e7-8868-a9a7454ada1e)
